### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-	"illuminate/support": "5.*",
+	"illuminate/support": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
 	"guzzlehttp/guzzle": "^6.2"
     },
     "require-dev": {


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.